### PR TITLE
feat(obs): reuse existing sponsors panel to show the sponsors in obs

### DIFF
--- a/content/obs/sponsors-panel.md
+++ b/content/obs/sponsors-panel.md
@@ -1,4 +1,3 @@
 ---
 title: "Sponsors Panel"
-date: 2025-11-07T10:00:00+01:00
 ---

--- a/layouts/obs/single.html
+++ b/layouts/obs/single.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
-<html class="no-js" lang="{{ .Site.Language.Lang }}">
+<html lang="{{ .Site.Language.Lang }}">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{{ .Title }} - {{ .Site.Title }}</title>
-	<script>(function(d,e){d[e]=d[e].replace("no-js","js");})(document.documentElement,"className");</script>
 	<meta name="description" content="{{ .Params.Description }}">
 	<meta name="robots" content="noindex, nofollow">
 
@@ -14,6 +13,16 @@
 	{{- end }}
 
 	<link rel="shortcut icon" href="{{ "favicon.ico" | relURL }}">
+	<style>
+		body {
+			background: transparent !important;		
+			max-width: 300px;
+		}
+		.wrapper {
+			background: transparent !important;
+		}
+
+	</style>
 </head>
 <body class="body">
 	<div class="container container--outer">


### PR DESCRIPTION
Creates a minimal page at `/obs/sponsors-panel/` displaying only the sponsors widget for use with OBS (Open Broadcaster Software), without site navigation or layout elements.

## Changes

- **New OBS section**: `content/obs/sponsors-panel.md` with custom layout rendering only the sponsors widget
- **Layout**: `layouts/obs/single.html` outputs minimal HTML with `noindex,nofollow` meta tags, using sidebar styling to preserve the original widget appearance
- **Styling**: Uses the original sidebar widget styles with centered logos and proper headings

## Screenshot

<img width="1768" height="993" alt="image" src="https://github.com/user-attachments/assets/ad4737b9-36e9-4c53-85c6-55829e4b8f1a" />


The page is accessible at `/obs/sponsors-panel/` but excluded from search engine indexing. The layout uses `single.html` following Hugo's convention where this template name is used for rendering individual pages in a section. The widget is wrapped in an `<aside class="sidebar">` element to maintain the original sidebar styling with centered logos and proper formatting.
