### PR TITLE
Add bluesky profile support for speaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ hugo new content/speakers/<first_name>-<last_name>.md
 2. Edit the speaker metadata:
 
 - `title`: The readable name of the speaker
+- `bluesky` (optional): The Bluesky handle of the speaker (full handle like username.bsky.social).
 - `twitter` (optional): The Twitter handle of the speaker (without `@`)
+
+ If both `bluesky` and `twitter` are specified, only the Bluesky profile will be displayed.
 
 3. Add the speaker biography as content.
 
@@ -107,7 +110,7 @@ Sponsors data are located in three locations:
   - The event summary otherwise.
 - Speakers page in an automatec alphabetic index.
 - Speaker conference list from the speaker page is updated if a speaker is mentioned in an event content.
-- Speaker profile picture comes from the Twitter and is regularly updated.
+- Speaker profile picture comes from Bluesky (if available) or Twitter and is regularly updated. When both are specified, only Bluesky is displayed.
 
 ### Custom Shortcodes
 

--- a/archetypes/speakers.md
+++ b/archetypes/speakers.md
@@ -1,5 +1,6 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
+#bluesky: "username.bsky.social"
 #twitter: "twitter-handle"
 ---
 

--- a/content/speakers/bruce-bujon.md
+++ b/content/speakers/bruce-bujon.md
@@ -1,5 +1,6 @@
 ---
 title: "Bruce Bujon"
+bluesky: "hardcoding.fr"
 twitter: "HardCoding"
 ---
 

--- a/content/speakers/jean-christophe-sirot.md
+++ b/content/speakers/jean-christophe-sirot.md
@@ -1,5 +1,6 @@
 ---
 title: "Jean Christophe Sirot"
+"bluesky": "sirot.org"
 twitter: "jcsirot"
 ---
 

--- a/content/speakers/jose-paumard.md
+++ b/content/speakers/jose-paumard.md
@@ -1,5 +1,6 @@
 ---
 title: "José Paumard"
+bluesky: "josepaumard.bsky.social"
 twitter: "JosePaumard"
 ---
 

--- a/content/speakers/khanh-tuong-maudoux.md
+++ b/content/speakers/khanh-tuong-maudoux.md
@@ -1,5 +1,6 @@
 ---
 title: "Khanh Tuong Maudoux"
+bluesky: "jetoile.fr"
 twitter: "jetoile"
 ---
 

--- a/content/speakers/pierre-yves-fourmond.md
+++ b/content/speakers/pierre-yves-fourmond.md
@@ -1,5 +1,6 @@
 ---
 title: "Pierre-Yves Fourmond"
+bluesky: "pyfourmond.bsky.social"
 twitter: "grumpyf0x48"
 ---
 

--- a/content/speakers/sun-tan.md
+++ b/content/speakers/sun-tan.md
@@ -1,5 +1,6 @@
 ---
 title: "Sun Tan"
+bluesky: "sunix.org"
 twitter: "__sunix_"
 ---
 

--- a/layouts/speakers/single.html
+++ b/layouts/speakers/single.html
@@ -1,13 +1,25 @@
 {{ define "main" }}
 <main class="main" role="main">
 	<article class="post">
-        {{- if and .Params.twitter .Site.Params.Twitter }}
+        {{- if .Params.bluesky }}
+			{{- $blueskyProfileUrl := printf "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=%s" .Params.bluesky }}
+			{{- $blueskyUser := resources.GetRemote $blueskyProfileUrl | transform.Unmarshal }}
+			{{- with $blueskyUser.avatar }}
+				{{- $originalImage := resources.GetRemote . }}
+				{{- with $originalImage }}
+					{{- $image := .Resize "128x128" }}
+		<a href="https://bsky.app/profile/{{ $.Params.bluesky }}" title="{{ $.Title }} Bluesky profile" target="_blank">
+			<img src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" class="speaker-profile avatar" alt="{{ $.Title }} profile picture">
+		</a>
+				{{- end }}
+			{{- end }}
+        {{- else if and .Params.twitter .Site.Params.Twitter }}
 			{{- $twitterApiHeaders := dict "authorization" (printf "%s%s" "Bearer " .Site.Params.Twitter) }}
-			{{- $twitterUser :=  resources.GetRemote "https://api.twitter.com/1.1/users/show.json?screen_name=" .Params.twitter $twitterApiHeaders | transform.Unmarshal }}
+			{{- $twitterUser := resources.GetRemote (printf "https://api.twitter.com/1.1/users/show.json?screen_name=%s" .Params.twitter) $twitterApiHeaders | transform.Unmarshal }}
 			{{- $originalImage := resources.GetRemote (replace $twitterUser.profile_image_url_https "_normal" "") }}
 			{{- $image := $originalImage.Resize "128x128" }}
-		<a href="https://twitter.com/{{ .Params.twitter }}" title="{{ .Title }} Twitter profile" target="_blank">
-			<img src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" class="speaker-profile avatar" alt="{{ .Title }} profile picture">
+		<a href="https://twitter.com/{{ .Params.twitter }}" title="{{ $.Title }} Twitter profile" target="_blank">
+			<img src="{{ $image.RelPermalink }}" width="{{ $image.Width }}" height="{{ $image.Height }}" class="speaker-profile avatar" alt="{{ $.Title }} profile picture">
 		</a>
         {{- end }}
 		<header class="post__header">


### PR DESCRIPTION
This PR adds support for bluesky account on speaker profile.

Similarly to Twitter (now X), it shows profile picture and network links when the `bluesky` speaker page parameter is set with the speaker Bluesky handle.

I added few handles from the team to demonstrate usage and result.